### PR TITLE
Add optional fixed additional fields to the LogDNA metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can go to town on most other logback configurations but the LogDNA only has 
 * `<ingestKey>${LOGDNA_INGEST_KEY}</ingestKey>` signup to LogDNA and find this in your account profile
 * `<includeStacktrace>true</includeStacktrace>` this library can send multiline stacktraces (see image) - Raw syslog transport cannot
 * `<sendMDC>true</sendMDC>` copies over logback's Mapped Diagnostic Context [(MDC)](https://logback.qos.ch/manual/mdc.html) as LogDNA Metadata which are then indexed and searchable.
+* `<additionalFields><env>PROD</env></additionalFields>` adds fixed additional context as LogDNA Metadata to all logs
     
 ## More Info
 

--- a/src/main/java/net/_95point2/utils/LogDNAAppender.java
+++ b/src/main/java/net/_95point2/utils/LogDNAAppender.java
@@ -5,6 +5,7 @@ import java.net.InetAddress;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.json.JSONArray;
@@ -35,7 +36,8 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 	private String appName;
 	private boolean includeStacktrace = true;
 	private boolean sendMDC = true;
-	
+	private Map<String, String> additionalFields = new HashMap<>();
+
 	public LogDNAAppender() {
 		try {
 			this.hostname = InetAddress.getLocalHost().getHostName();
@@ -86,7 +88,11 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 			JSONObject meta = new JSONObject();
 			meta.put("logger", ev.getLoggerName());
 			line.put("meta", meta);
-			
+
+			for (Entry<String, String> entry : this.additionalFields.entrySet()) {
+				meta.put(entry.getKey(), entry.getValue());
+			}
+
 			if(this.sendMDC && !ev.getMDCPropertyMap().isEmpty()){
 				for(Entry<String,String> entry : ev.getMDCPropertyMap().entrySet()){
 					meta.put(entry.getKey(), entry.getValue());
@@ -130,6 +136,10 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 	
 	public void setSendMDC(boolean sendMDC) {
 		this.sendMDC = sendMDC;
+	}
+
+	public void setAdditionalFields(Map<String, String> additionalFields) {
+		this.additionalFields = additionalFields;
 	}
 
 	public void setIncludeStacktrace(boolean includeStacktrace) {


### PR DESCRIPTION
These additional fields are useful for global metadata like environment name and the app name as part of the metadata.