### PR TITLE
Allow tags to be sent to LogDNA

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,1 @@
+_extends: probot-settings

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can go to town on most other logback configurations but the LogDNA only has 
 * `<ingestKey>${LOGDNA_INGEST_KEY}</ingestKey>` signup to LogDNA and find this in your account profile
 * `<includeStacktrace>true</includeStacktrace>` this library can send multiline stacktraces (see image) - Raw syslog transport cannot
 * `<sendMDC>true</sendMDC>` copies over logback's Mapped Diagnostic Context [(MDC)](https://logback.qos.ch/manual/mdc.html) as LogDNA Metadata which are then indexed and searchable.
+* `<tags>production</tags>` Sets the tags to send to LogDNA, multiple tags should be comma-separated
     
 ## More Info
 

--- a/src/main/java/net/_95point2/utils/LogDNAAppender.java
+++ b/src/main/java/net/_95point2/utils/LogDNAAppender.java
@@ -5,7 +5,6 @@ import java.net.InetAddress;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map.Entry;
 
 import org.json.JSONArray;
@@ -97,10 +96,6 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 
 
 			lines.put(line);
-
-			HashMap<String,Object> params = new HashMap<>();
-			params.put("hostname", this.hostname);
-			params.put("now", System.currentTimeMillis());
 
 			StringBuilder path = new StringBuilder();
 			path.append("?hostname=").append(encode(this.hostname))

--- a/src/main/java/net/_95point2/utils/LogDNAAppender.java
+++ b/src/main/java/net/_95point2/utils/LogDNAAppender.java
@@ -141,7 +141,9 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 		this.includeStacktrace = includeStacktrace;
 	}
 
-	public void setTags(Collection<String> tags) { this.tags = encode(joined(tags, ",")); }
+	public void setTags(String tags) {
+		this.tags = encode(tags);
+	}
 
 	private static String encode(String str) {
         try 
@@ -153,16 +155,4 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
             return str;
         }
     }
-
-    private static String joined(Collection<String> strings, String seperator) {
-		StringBuilder sb = new StringBuilder();
-		String currSeperator = "";
-
-		for (String curr : strings) {
-			sb.append(currSeperator).append(curr);
-			currSeperator = seperator;
-		}
-
-		return sb.toString();
-	}
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,6 +7,7 @@
 		<appName>LogDNA-Logback-Test</appName>
 		<ingestKey>${LOGDNA_INGEST_KEY}</ingestKey>
 		<includeStacktrace>true</includeStacktrace>
+		<tags>test</tags>
   	</appender>
   	
   	<!-- ... and this one should be attached to the root -->


### PR DESCRIPTION
We use tags to set things like the environment - this allows these tags to be setup on the appender and sent to LogDNA