### PR TITLE
Missing caused by

### DIFF
--- a/src/main/java/net/_95point2/utils/LogDNAAppender.java
+++ b/src/main/java/net/_95point2/utils/LogDNAAppender.java
@@ -49,6 +49,23 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 		this.http = webb;
 	}
 	
+	
+	private void extract(StringBuilder sb, IThrowableProxy tp, boolean causedBy) {
+		sb.append("\n\n");
+		if(causedBy) {
+			sb.append("Caused by :");
+		}
+		sb.append(tp.getClassName()).append(": ").append(tp.getMessage());
+		for(StackTraceElementProxy ste : tp.getStackTraceElementProxyArray()){
+			sb.append("\n\t").append(ste.getSTEAsString());
+		}
+		
+		IThrowableProxy cause = tp.getCause();
+        if (cause != null) {
+            extract(sb, cause, true);
+        }
+	}
+	
 	@Override
 	protected void append(ILoggingEvent ev) 
 	{
@@ -64,11 +81,7 @@ public class LogDNAAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 				.append(ev.getFormattedMessage());
 		
 		if(ev.getThrowableProxy() != null && this.includeStacktrace){
-			IThrowableProxy tp = ev.getThrowableProxy();
-			sb.append("\n\n").append(tp.getClassName()).append(": ").append(tp.getMessage());
-			for(StackTraceElementProxy ste : tp.getStackTraceElementProxyArray()){
-				sb.append("\n\t").append(ste.getSTEAsString());
-			}
+			extract(sb, ev.getThrowableProxy(), false);			
 		}
 		
 		try


### PR DESCRIPTION
The caused by is not sent to logdna currently. For example running in an exceeption like this:

```
Exception r = new RuntimeException("Some message");
throw new RuntimeException("Some other message", r);
```

should output

```
Exception in thread "main" java.lang.RuntimeException: Some other message
    at Exceptions.main(Exceptions.java:4)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: java.lang.RuntimeException: Some message
    at Exceptions.main(Exceptions.java:3)
    ... 5 more
```
